### PR TITLE
Initialize COM and generate the cache on import

### DIFF
--- a/src/AutoItLibrary/__init__.py
+++ b/src/AutoItLibrary/__init__.py
@@ -23,6 +23,7 @@ __version__ = "1.1"
 #
 # Import the libraries we need
 #
+import pythoncom
 import win32com.client                  # For COM interface to AutoIt
 import sys                              # For command line args
 import os                               # For file path manipulation
@@ -37,6 +38,12 @@ except :
 # Fix https://github.com/nokia/robotframework-autoitlibrary/issues/13
 import re                                   # To detect Windows Disk root path (c:\, d:\, ..., etc)
 from robot.libraries.BuiltIn import BuiltIn # Get RobotFramework's ${OUTPUTDIR} to store screenshot image
+
+# Initialize COM for RIDE
+pythoncom.CoInitialize()
+
+# Generate cache to ensure the AutoItX3.dll methods are available for RobotFramework
+win32com.client.gencache.EnsureModule("{F8937E53-D444-4E71-9275-35B64210CC3B}", 0, 1, 0)
 
 #
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
 * fixes #19
 * fixes #21

I researched into this issue of "...No keyword with name 'Send' found"  on StackOverFlow of recent. This is the [answer] I posted.

A short reason:

> The generated cache done by `win32com\client\makepy.py` for AutoItLibrary from the setup.py is saved in the `%temp%\gen_py` folder. This is done only when setup.py is executed. If the `%temp%` directory is cleaned later, which removes the cache, then I notice keywords like `Send` may fail to be recognized by the robotframework.

and a short solution:

> Inserting `win32com.client.gencache.EnsureModule("{F8937E53-D444-4E71-9275-35B64210CC3B}", 0, 1, 0)` into `AutoItLibrary\__init__.py` should ensure the cache is always available for any AutoItX version.

It is a possible solution to commit. AutoItX 3.3.6.1 and latest AutoItX 3.3.14.5 use the same GUID string so the hardcoded line seems reasonable to insert.

This fixes the methods that were missing, though RIDE can display the `Library AutoItLibrary` line in red and the `Search Keywords` may be missing the AutoItLibrary keywords. The fix I found was to use `pythoncom.CoInitialize()` to initialize COM before dispatching `autoit.control`. RIDE logs and tests now display no errors.

So, robot needs the cache with the generated Python scripts. RIDE that runs robot, also needs the `pythoncom.CoInitialize()` as it kind of hooks in with it's COM listener.

Copying the generated Python file into the AutoItLibray folder and importing it works without the temp cache, though it does not ensure against AutoItX3.dll version change or perhaps any changes in `win32com` module code. So, use of the current temp cache may cause less issues.

Tested in Python 2.7, 3.5 and 3.7.

 [answer]: https://stackoverflow.com/a/60452441/9012170