### PR TITLE
Fixes to work with latest Python versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+build/**
+dist/**
+src/robotframework_autoitlibrary.egg-info/**
+**/__pycache__/**

--- a/Build.bat
+++ b/Build.bat
@@ -24,7 +24,7 @@
 IF EXIST .\dist   rmdir /S /Q .\dist
 IF EXIST .\build  rmdir /S /Q .\build
 call Make.bat
-python setup.py sdist --format=zip
+python -m build --sdist
 pause
 ::
 :: -------------------------------- End of file --------------------------------

--- a/Make.bat
+++ b/Make.bat
@@ -19,17 +19,11 @@
 ::
 ::-------------------------------------------------------------------------------
 ::
-:: Install the AutoItLibrary on the local PC
-::
-python setup.py install
 ::
 :: Build the updated documentation before installing again
 ::
-libdoc.py --output doc\AutoItLibrary.html AutoItLibrary
+libdoc.exe src\AutoItLibrary doc\AutoItLibrary.html
 ::
-:: Now install the AutoItLibrary on the local PC including the updated documentation
-::
-python setup.py install
 pause
 ::
 :: -------------------------------- End of file --------------------------------

--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,9 @@ Purpose: This is a Python "Distutils" setup program used to build installers for
 """
 __author__  = "Martin Taylor <cmtaylor@ti.com>"
 
-from distutils.core      import setup
-from distutils.sysconfig import get_python_lib
+from setuptools      import setup
+from setuptools.command.install import install
+from sysconfig import get_path
 import sys
 import os
 import shutil
@@ -45,6 +46,43 @@ object and provides additional high-level keywords implemented as
 methods in this class.
 """[1:-1]
 
+class InstallCommand(install):
+    def initialize_options(self):
+        install.initialize_options(self)
+
+    def finalize_options(self):
+        install.finalize_options(self)
+
+    def run(self):
+        RegisterAutoIT()
+        install.run(self)
+
+def RegisterAutoIT():
+    #
+    # Install and register AutoItX
+    #
+    print("[INF] In RegisterAutoIT with params " + " ".join(str(x) for x in sys.argv))
+    
+    if os.path.isfile(os.path.join(get_path('platlib'), "AutoItLibrary/lib/AutoItX3.dll")) :
+        print("[INF] Don't think we need to unregister the old one...")
+
+    instDir = os.path.normpath(os.path.join(get_path('platlib'), "AutoItLibrary/lib"))
+    if not os.path.isdir(instDir) :
+        os.makedirs(instDir)
+    instFile = os.path.normpath(os.path.join(instDir, "AutoItX3.dll"))
+    if "32bit" in platform.architecture()[0] :
+        print("[INF] Here is from 32bit OS")
+        shutil.copyfile("3rdPartyTools/AutoIt/AutoItX3.dll", instFile)
+    else :
+        shutil.copyfile("3rdPartyTools/AutoIt/lib64/AutoItX3.dll", instFile)
+    #
+    # Register the AutoItX COM object
+    # and make its methods known to Python
+    #
+    cmd = r"%SYSTEMROOT%\system32\regsvr32.exe /S " + '\"' + instFile + '\"'
+    print(cmd)
+    subprocess.check_call(cmd, shell=True) 
+
 def getWin32ComRomingPath():
     for dirpath, dirs, files in os.walk(os.getenv('APPDATA')):
         for filename in files:
@@ -55,50 +93,6 @@ def getWin32ComRomingPath():
     return None
 
 if __name__ == "__main__":
-    #
-    # Install the 3rd party packages
-    #
-    if sys.argv[1].lower() == "install" :
-        if os.name == "nt" :
-            #
-            # Install and register AutoItX
-            #
-            if os.path.isfile(os.path.join(get_python_lib(), "AutoItLibrary/lib/AutoItX3.dll")) :
-                print("Don't think we need to unregister the old one...")
-
-            instDir = os.path.normpath(os.path.join(get_python_lib(), "AutoItLibrary/lib"))
-            if not os.path.isdir(instDir) :
-                os.makedirs(instDir)
-            instFile = os.path.normpath(os.path.join(instDir, "AutoItX3.dll"))
-            if "32bit" in platform.architecture()[0] :
-                print("Here is from 32bit OS")
-                shutil.copyfile("3rdPartyTools/AutoIt/AutoItX3.dll", instFile)
-            else :
-                shutil.copyfile("3rdPartyTools/AutoIt/lib64/AutoItX3.dll", instFile)
-            #
-            # Register the AutoItX COM object
-            # and make its methods known to Python
-            #
-            cmd = r"%SYSTEMROOT%\system32\regsvr32.exe /S " + '\"' + instFile + '\"'
-            print(cmd)
-            subprocess.check_call(cmd, shell=True)
-            makepy = os.path.normpath(os.path.join(get_python_lib(), "win32com/client/makepy.py"))
-            if not os.path.isfile(makepy):
-                print("[WRN] No win32com in get_python_lib(). Try find in %APPDATA%.")
-                makepy = getWin32ComRomingPath()
-            #
-            # Make sure we have win32com installed
-            #
-            if makepy is None:
-                print("[ERR] AutoItLibrary requires win32com. See http://starship.python.net/crew/mhammond/win32/.")
-                sys.exit(2)
-
-            cmd = "python \"%s\" \"%s\"" % (makepy, instFile)
-            print(cmd)
-            subprocess.check_call(cmd)
-        else :
-            print("AutoItLibrary cannot be installed on non-Windows platforms.")
-            sys.exit(2)
     #
     # Figure out the install path
     #
@@ -122,7 +116,8 @@ if __name__ == "__main__":
           long_description = DESCRIPTION,
           package_dir  = {'' : "src"},
           packages     = ["AutoItLibrary"],
-          install_requires = ['pywin32', 'pillow'],
+          cmdclass     = {'install': InstallCommand},
+          install_requires = ['robotframework', 'pywin32', 'pillow'],
           data_files   = [(destPath,
                              ["COPYRIGHT.txt",
                               "LICENSE.txt",

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,9 @@ class InstallCommand(install):
         install.finalize_options(self)
 
     def run(self):
+        if os.name != "nt" :
+            print("AutoItLibrary cannot be installed on non-Windows platforms.")
+            sys.exit(2)
         RegisterAutoIT()
         install.run(self)
 

--- a/src/AutoItLibrary/__init__.py
+++ b/src/AutoItLibrary/__init__.py
@@ -60,13 +60,13 @@ class AutoItLibrary(Logger.Logger, Counter.Counter) :
     documentation for these keywords is available in the AutoItX documentation file:
     *AutoItX.chm*.  This file is installed as part of the installation of *AutoItLibrary* as:
 
-        C:\RobotFramework\Extensions\AutoItLibrary\AutoItX.chm
+        C:\\RobotFramework\\Extensions\\AutoItLibrary\\AutoItX.chm
 
     In order to discover the control identifiers in a given Windows GUI, AutoIt provides a standalone
     tool called the AutoIt Window Info Tool which is installed as part of the installation of
     *AutoItLibrary* as:
 
-        C:\RobotFramework\Extensions\AutoItLibrary\Au3Info.exe
+        C:\\RobotFramework\\Extensions\\AutoItLibrary\\Au3Info.exe
 
     This tool is documented here: http://www.autoitscript.com/autoit3/docs/intro/au3spy.htm
     """


### PR DESCRIPTION
This should fix #37 

Cause of this issue is that much of what robotframework-autoitlibrary does to install is deprecated and/or not recommend practices in newer pythons.   A complete rewrite would be better, but I managed to get it working with fairly minimal changes:

- Build.bat  
  - updated to call `python -m build` instead, as calling setup.py directly is deprecated
  - NOTE it now outputs a tar.gz instead of a zip, and zip does not seem supported by `build`
- Make.bat 
  - libdoc.py call changed to newer libdoc.exe from robotframework.  
  - removed both calls to setup.py, as calling directly is deprecated and it is unnecessary as libdoc does not require it; and build.bat does an install itself as part
- setup.py
  - updated to work on Python 3.12 with setuptools, as distutils is obsolete and has been removed
  - changed logic to hook into cmdclass instead of relying on `install` param to be passed which does not occur any more
  - removed unneeded makepy.py call, as the lib does it automatically already at run time
  - added robotframework as a dependency
- __init__.py 
   - updated to remove libdoc warning about \R escape sequence
